### PR TITLE
Other emissions

### DIFF
--- a/api/apiKey.js
+++ b/api/apiKey.js
@@ -1,0 +1,3 @@
+const apiKey = "655W95SHTK4MQGJR90P3BZYYSS6P";
+
+module.exports = apiKey;

--- a/api/controllers/emissions.js
+++ b/api/controllers/emissions.js
@@ -1,58 +1,60 @@
-const CheckQuery = (req, res) => {if (
-  req.query.passengers === undefined ||
-  req.query.distance === undefined
-) {
-  res.status(400).send();
-  return false;
-} else if (isNaN(req.query.passengers) || isNaN(req.query.distance)) {
-  res.status(400).send();
-  return false;
-} return true}
-
 const EmissionsController = {
-
-  GetPlaneEmissions: (req, res) => {
+  GetEmissions: (req, res) => {
     if (!CheckQuery(req, res)) {
-      return
+      return;
     }
-    let data = "";
+
     const URL = "https://beta3.api.climatiq.io/estimate";
 
-    fetch(URL, {
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
-      },
-      method: "POST",
-      body: JSON.stringify({
-        emission_factor: {
-          activity_id:
-            "passenger_flight-route_type_international-aircraft_type_na-distance_short_haul_lt_3700km-class_na-rf_included",
-          source: "GHG Protocol",
-          region: "GB",
-          year: "2021",
-          lca_activity: "fuel_combustion",
-        },
-        parameters: {
-          passengers: parseInt(req.query.passengers),
-          distance: parseInt(req.query.distance),
-          distance_unit: "km",
-        },
-      }),
-    })
-      .then((response) => {
-        return response.json();
-      })
-      .then((responseData) => {
-        data = responseData;
-        console.log(responseData);
-        res.status(200).json({ message: "ok", co2e: data.co2e });
-      })
-      .catch((error) => {
-        // res.status(404);
-        console.error(error);
-      });
+    GetPlaneEmissions(req, res, URL);
+  },
+};
+
+const CheckQuery = (req, res) => {
+  if (req.query.passengers === undefined || req.query.distance === undefined) {
+    res.status(400).send();
+    return false;
+  } else if (isNaN(req.query.passengers) || isNaN(req.query.distance)) {
+    res.status(400).send();
+    return false;
   }
+  return true;
+};
+
+const GetPlaneEmissions = (req, res, URL) => {
+  fetch(URL, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
+    },
+    method: "POST",
+    body: JSON.stringify({
+      emission_factor: {
+        activity_id:
+          "passenger_flight-route_type_international-aircraft_type_na-distance_short_haul_lt_3700km-class_na-rf_included",
+        source: "GHG Protocol",
+        region: "GB",
+        year: "2021",
+        lca_activity: "fuel_combustion",
+      },
+      parameters: {
+        passengers: parseInt(req.query.passengers),
+        distance: parseInt(req.query.distance),
+        distance_unit: "km",
+      },
+    }),
+  })
+    .then((response) => {
+      return response.json();
+    })
+    .then((responseData) => {
+      console.log(responseData);
+      res.status(200).json({ message: "ok", co2e: responseData.co2e });
+    })
+    .catch((error) => {
+      // res.status(404);
+      console.error(error);
+    });
 };
 
 module.exports = EmissionsController;

--- a/api/controllers/emissions.js
+++ b/api/controllers/emissions.js
@@ -1,18 +1,22 @@
+const CheckQuery = (req, res) => {if (
+  req.query.passengers === undefined ||
+  req.query.distance === undefined
+) {
+  res.status(400).send();
+  return false;
+} else if (isNaN(req.query.passengers) || isNaN(req.query.distance)) {
+  res.status(400).send();
+  return false;
+} return true}
+
 const EmissionsController = {
+
   GetPlaneEmissions: (req, res) => {
+    if (!CheckQuery(req, res)) {
+      return
+    }
     let data = "";
     const URL = "https://beta3.api.climatiq.io/estimate";
-
-    if (
-      req.query.passengers === undefined ||
-      req.query.distance === undefined
-    ) {
-      res.status(400).send();
-      return;
-    } else if (isNaN(req.query.passengers) || isNaN(req.query.distance)) {
-      res.status(400).send();
-      return;
-    }
 
     fetch(URL, {
       headers: {
@@ -48,7 +52,7 @@ const EmissionsController = {
         // res.status(404);
         console.error(error);
       });
-  },
+  }
 };
 
 module.exports = EmissionsController;

--- a/api/controllers/emissions.js
+++ b/api/controllers/emissions.js
@@ -39,6 +39,12 @@ const CheckQuery = (req, res) => {
   } else if (isNaN(req.query.passengers) || isNaN(req.query.distance)) {
     res.status(400).send();
     return false;
+  } else if (req.query.distance < 0 || req.query.passengers < 1) {
+    res.status(400).send();
+    return false;
+  } else if (!Number.isInteger(parseFloat(req.query.passengers))) {
+    res.status(400).send();
+    return false;
   }
   return true;
 };

--- a/api/controllers/emissions.js
+++ b/api/controllers/emissions.js
@@ -6,16 +6,18 @@ const EmissionsController = {
 
     const URL = "https://beta3.api.climatiq.io/estimate";
 
-    const planeEmissions = await GetPlaneEmissions(req, res, URL);
-    const trainEmissions = await GetTrainEmissions(req, res, URL);
-    const petrolCarEmissions = await GetPetrolCarEmissions(req, res, URL);
-    const electricCarEmissions = await GetElectricCarEmissions(req, res, URL);
+    const emissions = await Promise.all([
+      GetPlaneEmissions(req, res, URL), 
+      GetTrainEmissions(req, res, URL), 
+      GetPetrolCarEmissions(req, res, URL), 
+      GetElectricCarEmissions(req, res, URL)
+    ])
 
     res.status(200).json({message: 'OK', emissions: {
-      plane: planeEmissions,
-      train: trainEmissions,
-      petrolCar: petrolCarEmissions,
-      electricCar: electricCarEmissions,
+      plane: {total: emissions[0], perPassenger: emissions[0]/req.query.passengers},
+      train: {total: emissions[1], perPassenger: emissions[1]/req.query.passengers},
+      petrolCar: {total: emissions[2], perPassenger: emissions[2]/req.query.passengers},
+      electricCar: {total: emissions[3], perPassenger: emissions[3]/req.query.passengers},
     }})
   },
 };
@@ -48,7 +50,6 @@ const GetElectricCarEmissions = (req, res, URL) => {
         lca_activity: "electricity_generation",
       },
       parameters: {
-        passengers: parseInt(req.query.passengers),
         distance: parseInt(req.query.distance),
         distance_unit: "km",
       },
@@ -83,16 +84,18 @@ const GetPetrolCarEmissions = (req, res, URL) => {
         lca_activity: "fuel_combustion",
       },
       parameters: {
-        passengers: parseInt(req.query.passengers),
         distance: parseInt(req.query.distance),
         distance_unit: "km",
       },
     }),
   })
     .then((response) => {
+      console.log("get petrol method" + response)
       return response.json();
     })
     .then((responseData) => {
+      console.log(responseData)
+
       return responseData.co2e;
     })
     .catch((error) => {

--- a/api/controllers/emissions.js
+++ b/api/controllers/emissions.js
@@ -8,6 +8,8 @@ const EmissionsController = {
 
     GetPlaneEmissions(req, res, URL);
     GetTrainEmissions(req, res, URL);
+    GetPetrolCarEmissions(req, res, URL);
+    GetElectricCarEmissions(req, res, URL);
   },
 };
 
@@ -20,6 +22,78 @@ const CheckQuery = (req, res) => {
     return false;
   }
   return true;
+};
+
+const GetElectricCarEmissions = (req, res, URL) => {
+  fetch(URL, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
+    },
+    method: "POST",
+    body: JSON.stringify({
+      emission_factor: {
+        activity_id:
+          "passenger_vehicle-vehicle_type_car-fuel_source_bev-engine_size_na-vehicle_age_na-vehicle_weight_na",
+        source: "BEIS",
+        region: "GB",
+        year: "2022",
+        lca_activity: "electricity_generation",
+      },
+      parameters: {
+        passengers: parseInt(req.query.passengers),
+        distance: parseInt(req.query.distance),
+        distance_unit: "km",
+      },
+    }),
+  })
+    .then((response) => {
+      return response.json();
+    })
+    .then((responseData) => {
+      console.log(responseData);
+      res.status(200).json({ message: "ok", co2e: responseData.co2e });
+    })
+    .catch((error) => {
+      // res.status(404);
+      console.error(error);
+    });
+};
+
+const GetPetrolCarEmissions = (req, res, URL) => {
+  fetch(URL, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
+    },
+    method: "POST",
+    body: JSON.stringify({
+      emission_factor: {
+        activity_id:
+          "passenger_vehicle-vehicle_type_car-fuel_source_petrol-engine_size_na-vehicle_age_na-vehicle_weight_na",
+        source: "BEIS",
+        region: "GB",
+        year: "2022",
+        lca_activity: "fuel_combustion",
+      },
+      parameters: {
+        passengers: parseInt(req.query.passengers),
+        distance: parseInt(req.query.distance),
+        distance_unit: "km",
+      },
+    }),
+  })
+    .then((response) => {
+      return response.json();
+    })
+    .then((responseData) => {
+      console.log(responseData);
+      res.status(200).json({ message: "ok", co2e: responseData.co2e });
+    })
+    .catch((error) => {
+      // res.status(404);
+      console.error(error);
+    });
 };
 
 const GetTrainEmissions = (req, res, URL) => {

--- a/api/controllers/emissions.js
+++ b/api/controllers/emissions.js
@@ -16,25 +16,20 @@ const EmissionsController = {
     res.status(200).json({
       message: "OK",
       emissions: {
-        plane: {
-          total: emissions[0],
-          perPassenger: emissions[0] / req.query.passengers,
-        },
-        train: {
-          total: emissions[1],
-          perPassenger: emissions[1] / req.query.passengers,
-        },
-        petrolCar: {
-          total: emissions[2],
-          perPassenger: emissions[2] / req.query.passengers,
-        },
-        electricCar: {
-          total: emissions[3],
-          perPassenger: emissions[3] / req.query.passengers,
-        },
+        plane: formatEmissions(emissions[0], req.query.passengers),
+        train: formatEmissions(emissions[1], req.query.passengers),
+        petrolCar: formatEmissions(emissions[2], req.query.passengers),
+        electricCar: formatEmissions(emissions[3], req.query.passengers),
       },
     });
   },
+};
+
+const formatEmissions = (emissions, passengers) => {
+  return {
+    total: emissions,
+    perPassenger: emissions / passengers,
+  };
 };
 
 const CheckQuery = (req, res) => {

--- a/api/controllers/emissions.js
+++ b/api/controllers/emissions.js
@@ -1,15 +1,22 @@
 const EmissionsController = {
-  GetEmissions: (req, res) => {
+  GetEmissions: async (req, res) => {
     if (!CheckQuery(req, res)) {
       return;
     }
 
     const URL = "https://beta3.api.climatiq.io/estimate";
 
-    GetPlaneEmissions(req, res, URL);
-    GetTrainEmissions(req, res, URL);
-    GetPetrolCarEmissions(req, res, URL);
-    GetElectricCarEmissions(req, res, URL);
+    const planeEmissions = await GetPlaneEmissions(req, res, URL);
+    const trainEmissions = await GetTrainEmissions(req, res, URL);
+    const petrolCarEmissions = await GetPetrolCarEmissions(req, res, URL);
+    const electricCarEmissions = await GetElectricCarEmissions(req, res, URL);
+
+    res.status(200).json({message: 'OK', emissions: {
+      plane: planeEmissions,
+      train: trainEmissions,
+      petrolCar: petrolCarEmissions,
+      electricCar: electricCarEmissions,
+    }})
   },
 };
 
@@ -25,7 +32,7 @@ const CheckQuery = (req, res) => {
 };
 
 const GetElectricCarEmissions = (req, res, URL) => {
-  fetch(URL, {
+  return fetch(URL, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
@@ -51,8 +58,7 @@ const GetElectricCarEmissions = (req, res, URL) => {
       return response.json();
     })
     .then((responseData) => {
-      console.log(responseData);
-      res.status(200).json({ message: "ok", co2e: responseData.co2e });
+      return responseData.co2e
     })
     .catch((error) => {
       // res.status(404);
@@ -61,7 +67,7 @@ const GetElectricCarEmissions = (req, res, URL) => {
 };
 
 const GetPetrolCarEmissions = (req, res, URL) => {
-  fetch(URL, {
+  return fetch(URL, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
@@ -87,8 +93,7 @@ const GetPetrolCarEmissions = (req, res, URL) => {
       return response.json();
     })
     .then((responseData) => {
-      console.log(responseData);
-      res.status(200).json({ message: "ok", co2e: responseData.co2e });
+      return responseData.co2e;
     })
     .catch((error) => {
       // res.status(404);
@@ -97,7 +102,7 @@ const GetPetrolCarEmissions = (req, res, URL) => {
 };
 
 const GetTrainEmissions = (req, res, URL) => {
-  fetch(URL, {
+  return fetch(URL, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
@@ -123,8 +128,7 @@ const GetTrainEmissions = (req, res, URL) => {
       return response.json();
     })
     .then((responseData) => {
-      console.log(responseData);
-      res.status(200).json({ message: "ok", co2e: responseData.co2e });
+      return responseData.co2e;
     })
     .catch((error) => {
       // res.status(404);
@@ -133,7 +137,7 @@ const GetTrainEmissions = (req, res, URL) => {
 };
 
 const GetPlaneEmissions = (req, res, URL) => {
-  fetch(URL, {
+  return fetch(URL, {
     headers: {
       "Content-Type": "application/json",
       Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
@@ -159,8 +163,7 @@ const GetPlaneEmissions = (req, res, URL) => {
       return response.json();
     })
     .then((responseData) => {
-      console.log(responseData);
-      res.status(200).json({ message: "ok", co2e: responseData.co2e });
+      return responseData.co2e;
     })
     .catch((error) => {
       // res.status(404);

--- a/api/controllers/emissions.js
+++ b/api/controllers/emissions.js
@@ -7,6 +7,7 @@ const EmissionsController = {
     const URL = "https://beta3.api.climatiq.io/estimate";
 
     GetPlaneEmissions(req, res, URL);
+    GetTrainEmissions(req, res, URL);
   },
 };
 
@@ -19,6 +20,42 @@ const CheckQuery = (req, res) => {
     return false;
   }
   return true;
+};
+
+const GetTrainEmissions = (req, res, URL) => {
+  fetch(URL, {
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${process.env.CLIMATIQ_KEY}`,
+    },
+    method: "POST",
+    body: JSON.stringify({
+      emission_factor: {
+        activity_id:
+          "passenger_train-route_type_international_rail-fuel_source_na",
+        source: "BEIS",
+        region: "GB",
+        year: "2022",
+        lca_activity: "fuel_combustion",
+      },
+      parameters: {
+        passengers: parseInt(req.query.passengers),
+        distance: parseInt(req.query.distance),
+        distance_unit: "km",
+      },
+    }),
+  })
+    .then((response) => {
+      return response.json();
+    })
+    .then((responseData) => {
+      console.log(responseData);
+      res.status(200).json({ message: "ok", co2e: responseData.co2e });
+    })
+    .catch((error) => {
+      // res.status(404);
+      console.error(error);
+    });
 };
 
 const GetPlaneEmissions = (req, res, URL) => {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@types/jest": "^29.4.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -1103,7 +1104,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "dependencies": {
         "@babel/highlight": "^7.18.6"
       },
@@ -1355,7 +1355,6 @@
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
       "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1387,7 +1386,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -1401,7 +1399,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^1.9.0"
       },
@@ -1413,7 +1410,6 @@
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -1427,7 +1423,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "dependencies": {
         "color-name": "1.1.3"
       }
@@ -1435,14 +1430,12 @@
     "node_modules/@babel/highlight/node_modules/color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-      "dev": true
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
     },
     "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-      "dev": true,
       "engines": {
         "node": ">=0.8.0"
       }
@@ -1835,7 +1828,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.1.tgz",
       "integrity": "sha512-w6YJMn5DlzmxjO00i9wu2YSozUYRBhIoJ6nQwpMYcBMtiqMGJm1QBzOf6DDgRao8dbtpDoaqLg6iiQTvv0UHhQ==",
-      "dev": true,
       "dependencies": {
         "jest-get-type": "^29.2.0"
       },
@@ -1922,7 +1914,6 @@
       "version": "29.4.0",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.0.tgz",
       "integrity": "sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==",
-      "dev": true,
       "dependencies": {
         "@sinclair/typebox": "^0.25.16"
       },
@@ -2004,7 +1995,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
       "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
-      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.4.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -2067,8 +2057,7 @@
     "node_modules/@sinclair/typebox": {
       "version": "0.25.21",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
-      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
-      "dev": true
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "node_modules/@sinonjs/commons": {
       "version": "2.0.0",
@@ -2141,14 +2130,12 @@
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
-      "dev": true
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g=="
     },
     "node_modules/@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -2157,9 +2144,17 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.4.0.tgz",
+      "integrity": "sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/node": {
@@ -2176,8 +2171,7 @@
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
+      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
     "node_modules/@types/webidl-conversions": {
       "version": "7.0.0",
@@ -2197,7 +2191,6 @@
       "version": "17.0.20",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
       "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
-      "dev": true,
       "dependencies": {
         "@types/yargs-parser": "*"
       }
@@ -2205,8 +2198,7 @@
     "node_modules/@types/yargs-parser": {
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
-      "dev": true
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
     "node_modules/abbrev": {
       "version": "1.1.1",
@@ -2253,7 +2245,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -2607,7 +2598,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2623,7 +2613,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2632,7 +2621,6 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },
@@ -2679,7 +2667,6 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
       "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2730,7 +2717,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2741,8 +2727,7 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2913,7 +2898,6 @@
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
       "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
-      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -2990,7 +2974,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
       "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -3052,7 +3035,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.1.tgz",
       "integrity": "sha512-OKrGESHOaMxK3b6zxIq9SOW8kEXztKff/Dvg88j4xIJxur1hspEbedVkR3GpHe5LO+WB2Qw7OWN0RMTdp6as5A==",
-      "dev": true,
       "dependencies": {
         "@jest/expect-utils": "^29.4.1",
         "jest-get-type": "^29.2.0",
@@ -3344,8 +3326,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -3869,7 +3850,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.1.tgz",
       "integrity": "sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==",
-      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.3.1",
@@ -3939,7 +3919,6 @@
       "version": "29.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
       "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
-      "dev": true,
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -3986,7 +3965,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.1.tgz",
       "integrity": "sha512-k5h0u8V4nAEy6lSACepxL/rw78FLDkBnXhZVgFneVpnJONhb2DhZj/Gv4eNe+1XqQ5IhgUcqj745UwH0HJmMnA==",
-      "dev": true,
       "dependencies": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.4.1",
@@ -4001,7 +3979,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.1.tgz",
       "integrity": "sha512-H4/I0cXUaLeCw6FM+i4AwCnOwHRgitdaUFOdm49022YD5nfyr8C/DrbXOBEyJaj+w/y0gGJ57klssOaUiLLQGQ==",
-      "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.4.1",
@@ -4261,7 +4238,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
       "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
-      "dev": true,
       "dependencies": {
         "@jest/types": "^29.4.1",
         "@types/node": "*",
@@ -4364,8 +4340,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -4533,7 +4508,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "dependencies": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -5038,7 +5012,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
       "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
-      "dev": true,
       "dependencies": {
         "@jest/schemas": "^29.4.0",
         "ansi-styles": "^5.0.0",
@@ -5052,7 +5025,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5143,8 +5115,7 @@
     "node_modules/react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -5378,7 +5349,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -5443,7 +5413,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
       "dependencies": {
         "escape-string-regexp": "^2.0.0"
       },
@@ -6897,7 +6866,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
       "integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-      "dev": true,
       "requires": {
         "@babel/highlight": "^7.18.6"
       }
@@ -7088,8 +7056,7 @@
     "@babel/helper-validator-identifier": {
       "version": "7.19.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
-      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
-      "dev": true
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w=="
     },
     "@babel/helper-validator-option": {
       "version": "7.18.6",
@@ -7112,7 +7079,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
       "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-      "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.18.6",
         "chalk": "^2.0.0",
@@ -7123,7 +7089,6 @@
           "version": "3.2.1",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "dev": true,
           "requires": {
             "color-convert": "^1.9.0"
           }
@@ -7132,7 +7097,6 @@
           "version": "2.4.2",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
           "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -7143,7 +7107,6 @@
           "version": "1.9.3",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
           "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
@@ -7151,14 +7114,12 @@
         "color-name": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-          "dev": true
+          "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
         },
         "escape-string-regexp": {
           "version": "1.0.5",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-          "dev": true
+          "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="
         }
       }
     },
@@ -7452,7 +7413,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.4.1.tgz",
       "integrity": "sha512-w6YJMn5DlzmxjO00i9wu2YSozUYRBhIoJ6nQwpMYcBMtiqMGJm1QBzOf6DDgRao8dbtpDoaqLg6iiQTvv0UHhQ==",
-      "dev": true,
       "requires": {
         "jest-get-type": "^29.2.0"
       }
@@ -7519,7 +7479,6 @@
       "version": "29.4.0",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.4.0.tgz",
       "integrity": "sha512-0E01f/gOZeNTG76i5eWWSupvSHaIINrTie7vCyjiYFKgzNdyEGd12BUv4oNBFHOqlHDbtoJi3HrQ38KCC90NsQ==",
-      "dev": true,
       "requires": {
         "@sinclair/typebox": "^0.25.16"
       }
@@ -7586,7 +7545,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/@jest/types/-/types-29.4.1.tgz",
       "integrity": "sha512-zbrAXDUOnpJ+FMST2rV7QZOgec8rskg2zv8g2ajeqitp4tvZiyqTCYXANrKsM+ryj5o+LI+ZN2EgU9drrkiwSA==",
-      "dev": true,
       "requires": {
         "@jest/schemas": "^29.4.0",
         "@types/istanbul-lib-coverage": "^2.0.0",
@@ -7637,8 +7595,7 @@
     "@sinclair/typebox": {
       "version": "0.25.21",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
-      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g==",
-      "dev": true
+      "integrity": "sha512-gFukHN4t8K4+wVC+ECqeqwzBDeFeTzBXroBTqE6vcWrQGbEUpHO7LYdG0f4xnvYq4VOEwITSlHlp0JBAIFMS/g=="
     },
     "@sinonjs/commons": {
       "version": "2.0.0",
@@ -7711,14 +7668,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
-      "dev": true
+      "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g=="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -7727,9 +7682,17 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "@types/jest": {
+      "version": "29.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.4.0.tgz",
+      "integrity": "sha512-VaywcGQ9tPorCX/Jkkni7RWGFfI11whqzs8dvxF41P17Z+z872thvEvlIbznjPJ02kl1HMX3LmLOonsj2n7HeQ==",
+      "requires": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "@types/node": {
@@ -7746,8 +7709,7 @@
     "@types/stack-utils": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
+      "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw=="
     },
     "@types/webidl-conversions": {
       "version": "7.0.0",
@@ -7767,7 +7729,6 @@
       "version": "17.0.20",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.20.tgz",
       "integrity": "sha512-eknWrTHofQuPk2iuqDm1waA7V6xPlbgBoaaXEgYkClhLOnB0TtbW+srJaOToAgawPxPlHQzwypFA2bhZaUGP5A==",
-      "dev": true,
       "requires": {
         "@types/yargs-parser": "*"
       }
@@ -7775,8 +7736,7 @@
     "@types/yargs-parser": {
       "version": "21.0.0",
       "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.0.tgz",
-      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==",
-      "dev": true
+      "integrity": "sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA=="
     },
     "abbrev": {
       "version": "1.1.1",
@@ -7811,7 +7771,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
       "requires": {
         "color-convert": "^2.0.1"
       }
@@ -8056,7 +8015,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -8065,14 +8023,12 @@
         "has-flag": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
         },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
           "requires": {
             "has-flag": "^4.0.0"
           }
@@ -8103,8 +8059,7 @@
     "ci-info": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.7.1.tgz",
-      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w==",
-      "dev": true
+      "integrity": "sha512-4jYS4MOAaCIStSRwiuxc4B8MYhIe676yO1sYGzARnjXkWpmzZMMYxY6zu8WYWDhSuth5zhrQ1rhNSibyyvv4/w=="
     },
     "cjs-module-lexer": {
       "version": "1.2.2",
@@ -8139,7 +8094,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
       "requires": {
         "color-name": "~1.1.4"
       }
@@ -8147,8 +8101,7 @@
     "color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "combined-stream": {
       "version": "1.0.8",
@@ -8284,8 +8237,7 @@
     "diff-sequences": {
       "version": "29.3.1",
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.3.1.tgz",
-      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ==",
-      "dev": true
+      "integrity": "sha512-hlM3QR272NXCi4pq+N4Kok4kOp6EsgOM3ZSpJI7Da3UAs+Ttsi8MRmB6trM/lhyzUxGfOgnpkHtgqm5Q/CTcfQ=="
     },
     "dotenv": {
       "version": "16.0.3",
@@ -8343,8 +8295,7 @@
     "escape-string-regexp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-      "dev": true
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
     },
     "esprima": {
       "version": "4.0.1",
@@ -8384,7 +8335,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-29.4.1.tgz",
       "integrity": "sha512-OKrGESHOaMxK3b6zxIq9SOW8kEXztKff/Dvg88j4xIJxur1hspEbedVkR3GpHe5LO+WB2Qw7OWN0RMTdp6as5A==",
-      "dev": true,
       "requires": {
         "@jest/expect-utils": "^29.4.1",
         "jest-get-type": "^29.2.0",
@@ -8605,8 +8555,7 @@
     "graceful-fs": {
       "version": "4.2.10",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
-      "dev": true
+      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA=="
     },
     "has": {
       "version": "1.0.3",
@@ -8975,7 +8924,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.4.1.tgz",
       "integrity": "sha512-uazdl2g331iY56CEyfbNA0Ut7Mn2ulAG5vUaEHXycf1L6IPyuImIxSz4F0VYBKi7LYIuxOwTZzK3wh5jHzASMw==",
-      "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "diff-sequences": "^29.3.1",
@@ -9032,8 +8980,7 @@
     "jest-get-type": {
       "version": "29.2.0",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.2.0.tgz",
-      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA==",
-      "dev": true
+      "integrity": "sha512-uXNJlg8hKFEnDgFsrCjznB+sTxdkuqiCL6zMgA75qEbAJjJYTs9XPrvDctrEig2GDow22T/LvHgO57iJhXB/UA=="
     },
     "jest-haste-map": {
       "version": "29.4.1",
@@ -9069,7 +9016,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.4.1.tgz",
       "integrity": "sha512-k5h0u8V4nAEy6lSACepxL/rw78FLDkBnXhZVgFneVpnJONhb2DhZj/Gv4eNe+1XqQ5IhgUcqj745UwH0HJmMnA==",
-      "dev": true,
       "requires": {
         "chalk": "^4.0.0",
         "jest-diff": "^29.4.1",
@@ -9081,7 +9027,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.4.1.tgz",
       "integrity": "sha512-H4/I0cXUaLeCw6FM+i4AwCnOwHRgitdaUFOdm49022YD5nfyr8C/DrbXOBEyJaj+w/y0gGJ57klssOaUiLLQGQ==",
-      "dev": true,
       "requires": {
         "@babel/code-frame": "^7.12.13",
         "@jest/types": "^29.4.1",
@@ -9293,7 +9238,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-29.4.1.tgz",
       "integrity": "sha512-bQy9FPGxVutgpN4VRc0hk6w7Hx/m6L53QxpDreTZgJd9gfx/AV2MjyPde9tGyZRINAUrSv57p2inGBu2dRLmkQ==",
-      "dev": true,
       "requires": {
         "@jest/types": "^29.4.1",
         "@types/node": "*",
@@ -9373,8 +9317,7 @@
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -9502,7 +9445,6 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
-      "dev": true,
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
@@ -9871,7 +9813,6 @@
       "version": "29.4.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.4.1.tgz",
       "integrity": "sha512-dt/Z761JUVsrIKaY215o1xQJBGlSmTx/h4cSqXqjHLnU1+Kt+mavVE7UgqJJO5ukx5HjSswHfmXz4LjS2oIJfg==",
-      "dev": true,
       "requires": {
         "@jest/schemas": "^29.4.0",
         "ansi-styles": "^5.0.0",
@@ -9881,8 +9822,7 @@
         "ansi-styles": {
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
-          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
-          "dev": true
+          "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="
         }
       }
     },
@@ -9948,8 +9888,7 @@
     "react-is": {
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
-      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "dev": true
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
     },
     "readdirp": {
       "version": "3.6.0",
@@ -10124,8 +10063,7 @@
     "slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-      "dev": true
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
     },
     "smart-buffer": {
       "version": "4.2.0",
@@ -10176,7 +10114,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
       "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-      "dev": true,
       "requires": {
         "escape-string-regexp": "^2.0.0"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@types/jest": "^29.4.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",
@@ -23,7 +24,4 @@
     "jest": "^29.4.1",
     "jest-fetch-mock": "^3.0.3"
   }
-
-  }
-
- 
+}

--- a/api/routes/emissions.js
+++ b/api/routes/emissions.js
@@ -3,6 +3,8 @@ const router = express.Router();
 
 const EmissionsController = require("../controllers/emissions");
 
-router.get("/", (req, res) => {EmissionsController.GetPlaneEmissions(req, res)});
+router.get("/", (req, res) => {
+  EmissionsController.GetEmissions(req, res);
+});
 
 module.exports = router;

--- a/api/routes/emissions.js
+++ b/api/routes/emissions.js
@@ -3,6 +3,6 @@ const router = express.Router();
 
 const EmissionsController = require("../controllers/emissions");
 
-router.get("/plane", EmissionsController.GetPlaneEmissions);
+router.get("/", (req, res) => {EmissionsController.GetPlaneEmissions(req, res)});
 
 module.exports = router;

--- a/api/spec/controllers/emissions.spec.js
+++ b/api/spec/controllers/emissions.spec.js
@@ -3,27 +3,29 @@ const request = require("supertest");
 require("jest-fetch-mock").enableMocks();
 
 describe("/emissions", () => {
-  test("response code is 400 if the passengers query parameter is not numerical", async () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
 
-    let response = await request(app).get("/emissions?distance=100&passengers=person");
+  test("response code is 400 if the passengers query parameter is not numerical", async () => {
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=person"
+    );
 
     expect(response.status).toEqual(400);
-
   });
 
   test("response code is 400 if the distance query parameter is not numerical", async () => {
+    let response = await request(app).get(
+      "/emissions?distance=one&passengers=1"
+    );
 
-    let response = await request(app).get("/emissions?distance=one&passengers=1");
-    
     expect(response.status).toEqual(400);
-
   });
 
   test("response code is 400 if no query parameters are given", async () => {
-
     let response = await request(app).get("/emissions");
     expect(response.status).toEqual(400);
-
   });
 
   test("response code is 200 when given distance and passengers params", async () => {
@@ -38,7 +40,7 @@ describe("/emissions", () => {
     expect(response.status).toEqual(200);
   });
 
-  test("calls fetch and loads the co2e value", async () => {
+  test("calls fetch for plane co2e value", async () => {
     fetch.mockResponse(
       JSON.stringify({
         co2e: 63.094792,
@@ -47,6 +49,38 @@ describe("/emissions", () => {
     let response = await request(app).get(
       "/emissions?distance=100&passengers=1"
     );
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "passenger_flight-route_type_international-aircraft_type_na-distance_short_haul_lt_3700km-class_na-rf_included"
+        ),
+      })
+    );
+  });
+
+  test("calls fetch for train co2e value", async () => {
+    fetch.mockResponse(
+      JSON.stringify({
+        co2e: 63.094792,
+      })
+    );
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=1"
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "passenger_train-route_type_international_rail-fuel_source_na",
+          "fuel_combustion",
+          "2022"
+        ),
+      })
+    );
+
     expect(response.status).toEqual(200);
     expect(response.body.co2e).toEqual(63.094792);
   });

--- a/api/spec/controllers/emissions.spec.js
+++ b/api/spec/controllers/emissions.spec.js
@@ -81,8 +81,6 @@ describe("/emissions", () => {
       })
     );
 
-    expect(response.status).toEqual(200);
-    expect(response.body.co2e).toEqual(63.094792);
   });
 
   test("calls fetch for Petrol car co2e value", async () => {
@@ -106,8 +104,6 @@ describe("/emissions", () => {
       })
     );
 
-    expect(response.status).toEqual(200);
-    expect(response.body.co2e).toEqual(63.094792);
   });
 
   test("calls fetch for EV car co2e value", async () => {
@@ -131,7 +127,37 @@ describe("/emissions", () => {
       })
     );
 
-    expect(response.status).toEqual(200);
-    expect(response.body.co2e).toEqual(63.094792);
   });
+
+  test('fetch results are grouped into single response, for total emissions', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        co2e: 63.094792,
+      })
+    );
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        co2e: 20.094792,
+      })
+    );
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        co2e: 10.094792,
+      })
+    );
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        co2e: 1.094792,
+      })
+    );
+
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=1"
+    );
+
+    expect(response.body.emissions.plane).toEqual(63.094792);
+    expect(response.body.emissions.train).toEqual(20.094792);
+    expect(response.body.emissions.petrolCar).toEqual(10.094792);
+    expect(response.body.emissions.electricCar).toEqual(1.094792);
+  })
 });

--- a/api/spec/controllers/emissions.spec.js
+++ b/api/spec/controllers/emissions.spec.js
@@ -28,6 +28,30 @@ describe("/emissions", () => {
     expect(response.status).toEqual(400);
   });
 
+  test("response code is 400 if the distance query parameter is not positive", async () => {
+    let response = await request(app).get(
+      "/emissions?distance=-3&passengers=1"
+    );
+
+    expect(response.status).toEqual(400);
+  });
+
+  test("response code is 400 if the passengers query parameter is less than 1", async () => {
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=0"
+    );
+
+    expect(response.status).toEqual(400);
+  });
+
+  test("response code is 400 if the passengers query parameter is an integer", async () => {
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=2.5"
+    );
+
+    expect(response.status).toEqual(400);
+  });
+
   test("response code is 200 when given distance and passengers params", async () => {
     fetch.mockResponse(
       JSON.stringify({
@@ -80,7 +104,6 @@ describe("/emissions", () => {
         ),
       })
     );
-
   });
 
   test("calls fetch for Petrol car co2e value", async () => {
@@ -103,7 +126,6 @@ describe("/emissions", () => {
         ),
       })
     );
-
   });
 
   test("calls fetch for EV car co2e value", async () => {
@@ -126,10 +148,9 @@ describe("/emissions", () => {
         ),
       })
     );
-
   });
 
-  test('fetch results are grouped into single response, with total emissions', async () => {
+  test("fetch results are grouped into single response, with total emissions", async () => {
     fetch.mockResponseOnce(
       JSON.stringify({
         co2e: 63.094792,
@@ -159,9 +180,9 @@ describe("/emissions", () => {
     expect(response.body.emissions.train.total).toEqual(20.094792);
     expect(response.body.emissions.petrolCar.total).toEqual(10.094792);
     expect(response.body.emissions.electricCar.total).toEqual(1.094792);
-  })
+  });
 
-  test('fetch results are grouped into single response, with per passenger emissions', async () => {
+  test("fetch results are grouped into single response, with per passenger emissions", async () => {
     fetch.mockResponseOnce(
       JSON.stringify({
         co2e: 63.094792,
@@ -187,9 +208,13 @@ describe("/emissions", () => {
       "/emissions?distance=100&passengers=4"
     );
 
-    expect(response.body.emissions.plane.perPassenger).toEqual(63.094792/4);
-    expect(response.body.emissions.train.perPassenger).toEqual(20.094792/4);
-    expect(response.body.emissions.petrolCar.perPassenger).toEqual(10.094792/4);
-    expect(response.body.emissions.electricCar.perPassenger).toEqual(1.094792/4);
-  })
+    expect(response.body.emissions.plane.perPassenger).toEqual(63.094792 / 4);
+    expect(response.body.emissions.train.perPassenger).toEqual(20.094792 / 4);
+    expect(response.body.emissions.petrolCar.perPassenger).toEqual(
+      10.094792 / 4
+    );
+    expect(response.body.emissions.electricCar.perPassenger).toEqual(
+      1.094792 / 4
+    );
+  });
 });

--- a/api/spec/controllers/emissions.spec.js
+++ b/api/spec/controllers/emissions.spec.js
@@ -84,4 +84,54 @@ describe("/emissions", () => {
     expect(response.status).toEqual(200);
     expect(response.body.co2e).toEqual(63.094792);
   });
+
+  test("calls fetch for Petrol car co2e value", async () => {
+    fetch.mockResponse(
+      JSON.stringify({
+        co2e: 63.094792,
+      })
+    );
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=1"
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "passenger_vehicle-vehicle_type_car-fuel_source_petrol-engine_size_na-vehicle_age_na-vehicle_weight_na",
+          "fuel_combustion",
+          "2022"
+        ),
+      })
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.body.co2e).toEqual(63.094792);
+  });
+
+  test("calls fetch for EV car co2e value", async () => {
+    fetch.mockResponse(
+      JSON.stringify({
+        co2e: 63.094792,
+      })
+    );
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=1"
+    );
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "passenger_vehicle-vehicle_type_car-fuel_source_bev-engine_size_na-vehicle_age_na-vehicle_weight_na",
+          "electricity_generation",
+          "2022"
+        ),
+      })
+    );
+
+    expect(response.status).toEqual(200);
+    expect(response.body.co2e).toEqual(63.094792);
+  });
 });

--- a/api/spec/controllers/emissions.spec.js
+++ b/api/spec/controllers/emissions.spec.js
@@ -129,7 +129,7 @@ describe("/emissions", () => {
 
   });
 
-  test('fetch results are grouped into single response, for total emissions', async () => {
+  test('fetch results are grouped into single response, with total emissions', async () => {
     fetch.mockResponseOnce(
       JSON.stringify({
         co2e: 63.094792,
@@ -155,9 +155,41 @@ describe("/emissions", () => {
       "/emissions?distance=100&passengers=1"
     );
 
-    expect(response.body.emissions.plane).toEqual(63.094792);
-    expect(response.body.emissions.train).toEqual(20.094792);
-    expect(response.body.emissions.petrolCar).toEqual(10.094792);
-    expect(response.body.emissions.electricCar).toEqual(1.094792);
+    expect(response.body.emissions.plane.total).toEqual(63.094792);
+    expect(response.body.emissions.train.total).toEqual(20.094792);
+    expect(response.body.emissions.petrolCar.total).toEqual(10.094792);
+    expect(response.body.emissions.electricCar.total).toEqual(1.094792);
+  })
+
+  test('fetch results are grouped into single response, with per passenger emissions', async () => {
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        co2e: 63.094792,
+      })
+    );
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        co2e: 20.094792,
+      })
+    );
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        co2e: 10.094792,
+      })
+    );
+    fetch.mockResponseOnce(
+      JSON.stringify({
+        co2e: 1.094792,
+      })
+    );
+
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=4"
+    );
+
+    expect(response.body.emissions.plane.perPassenger).toEqual(63.094792/4);
+    expect(response.body.emissions.train.perPassenger).toEqual(20.094792/4);
+    expect(response.body.emissions.petrolCar.perPassenger).toEqual(10.094792/4);
+    expect(response.body.emissions.electricCar.perPassenger).toEqual(1.094792/4);
   })
 });

--- a/api/spec/controllers/emissions.spec.js
+++ b/api/spec/controllers/emissions.spec.js
@@ -3,53 +3,51 @@ const request = require("supertest");
 require("jest-fetch-mock").enableMocks();
 
 describe("/emissions", () => {
-  describe("/plane", () => {
-    test("response code is 400 if the passengers query parameter is not numerical", async () => {
+  test("response code is 400 if the passengers query parameter is not numerical", async () => {
 
-      let response = await request(app).get("/emissions/plane?distance=100&passengers=person");
+    let response = await request(app).get("/emissions?distance=100&passengers=person");
 
-      expect(response.status).toEqual(400);
-  
-    });
+    expect(response.status).toEqual(400);
 
-    test("response code is 400 if the distance query parameter is not numerical", async () => {
+  });
 
-      let response = await request(app).get("/emissions/plane?distance=one&passengers=1");
-      
-      expect(response.status).toEqual(400);
-  
-    });
+  test("response code is 400 if the distance query parameter is not numerical", async () => {
 
-    test("response code is 400 if no query parameters are given", async () => {
+    let response = await request(app).get("/emissions?distance=one&passengers=1");
+    
+    expect(response.status).toEqual(400);
 
-      let response = await request(app).get("/emissions/plane");
-      expect(response.status).toEqual(400);
-  
-    });
+  });
 
-    test("response code is 200 when given distance and passengers params", async () => {
-      fetch.mockResponse(
-        JSON.stringify({
-          co2e: 63.094792,
-        })
-      );
-      let response = await request(app).get(
-        "/emissions/plane?distance=100&passengers=1"
-      );
-      expect(response.status).toEqual(200);
-    });
+  test("response code is 400 if no query parameters are given", async () => {
 
-    test("calls fetch and loads the co2e value", async () => {
-      fetch.mockResponse(
-        JSON.stringify({
-          co2e: 63.094792,
-        })
-      );
-      let response = await request(app).get(
-        "/emissions/plane?distance=100&passengers=1"
-      );
-      expect(response.status).toEqual(200);
-      expect(response.body.co2e).toEqual(63.094792);
-    });
+    let response = await request(app).get("/emissions");
+    expect(response.status).toEqual(400);
+
+  });
+
+  test("response code is 200 when given distance and passengers params", async () => {
+    fetch.mockResponse(
+      JSON.stringify({
+        co2e: 63.094792,
+      })
+    );
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=1"
+    );
+    expect(response.status).toEqual(200);
+  });
+
+  test("calls fetch and loads the co2e value", async () => {
+    fetch.mockResponse(
+      JSON.stringify({
+        co2e: 63.094792,
+      })
+    );
+    let response = await request(app).get(
+      "/emissions?distance=100&passengers=1"
+    );
+    expect(response.status).toEqual(200);
+    expect(response.body.co2e).toEqual(63.094792);
   });
 });


### PR DESCRIPTION
- Adds more api calls to the backend to get train, petrol car and electric car emissions.
- Returns total emissions and emissions per passenger
- Returns all emissions in one response object:`{ emissions: { plane: { total: ..., perPassenger: ...}, train: { ... }, petrolCar: { ... }, electricCar: { ... } } }`
- Checks `distance > 0`, `passengers > 1` and `passengers` is an integer

We also installed one npm package, so make sure you run `npm install` when you pull these changes.