### PR TITLE
Bcrypt encryption

### DIFF
--- a/api/controllers/users.js
+++ b/api/controllers/users.js
@@ -1,10 +1,20 @@
 const User = require("../models/user");
+const bcrypt = require("bcryptjs");
 
 const UsersController = {
-  Create: (req, res) => {
+  Create: async (req, res) => {
+    let encryptedPassword;
+    try {
+      encryptedPassword = await bcrypt
+        .genSalt(10)
+        .then((salt) => bcrypt.hash(req.body.password, salt));
+    } catch (err) {
+      return res.status(400).json({ message: "Bad request" });
+    }
+
     const user = new User({
       email: req.body.email,
-      password: req.body.password,
+      password: encryptedPassword,
     });
     user.save((err) => {
       if (err) {

--- a/api/models/user.js
+++ b/api/models/user.js
@@ -5,6 +5,7 @@ const UserSchema = new mongoose.Schema({
     type: String,
     required: true,
     unique: true,
+    dropDups: true,
     match: [/^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$/],
   },
   password: { type: String, required: true },

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -10,6 +10,7 @@
       "license": "ISC",
       "dependencies": {
         "@types/jest": "^29.4.0",
+        "bcryptjs": "^2.4.3",
         "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "express": "^4.18.2",
@@ -2405,6 +2406,11 @@
           "url": "https://feross.org/support"
         }
       ]
+    },
+    "node_modules/bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -7887,6 +7893,11 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bcryptjs": {
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/bcryptjs/-/bcryptjs-2.4.3.tgz",
+      "integrity": "sha512-V/Hy/X9Vt7f3BbPJEi8BdVFMByHi+jNXrYkW3huaybV/kQ0KJg0Y6PkEMbn+zeT+i+SiKZ/HMqJGIIt4LZDqNQ=="
     },
     "binary-extensions": {
       "version": "2.2.0",

--- a/api/package.json
+++ b/api/package.json
@@ -12,6 +12,7 @@
   "license": "ISC",
   "dependencies": {
     "@types/jest": "^29.4.0",
+    "bcryptjs": "^2.4.3",
     "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "express": "^4.18.2",

--- a/api/spec/controllers/users.spec.js
+++ b/api/spec/controllers/users.spec.js
@@ -84,4 +84,24 @@ describe("/users", () => {
       expect(users.length).toEqual(0);
     });
   });
+
+  describe("email has already been used", () => {
+    beforeEach(async () => {
+      await User.create({ email: "test@email.com", password: "password1" });
+    });
+    it("gives response code 400", async () => {
+      let response = await request(app)
+        .post("/users")
+        .send({ email: "test@email.com", password: "password2" });
+      expect(response.statusCode).toBe(400);
+    });
+
+    it("does not NOT create a user", async () => {
+      await request(app)
+        .post("/users")
+        .send({ email: "test@email.com", password: "password2" });
+      let users = await User.find();
+      expect(users.length).toEqual(1);
+    });
+  });
 });

--- a/api/spec/models/user.spec.js
+++ b/api/spec/models/user.spec.js
@@ -4,10 +4,8 @@ require("../mongodb_helper");
 const User = require("../../models/user");
 
 describe("User model", () => {
-  beforeEach((done) => {
-    mongoose.connection.collections.users.drop(() => {
-      done();
-    });
+  beforeEach(async () => {
+    await User.deleteMany();
   });
 
   it("has an email address", () => {
@@ -50,5 +48,25 @@ describe("User model", () => {
         done();
       });
     });
+  });
+
+  it("cannot have the same email as someone else", async () => {
+    const user1 = new User({
+      email: "test@email.com",
+      password: "password1",
+    });
+    await user1.save();
+
+    const user2 = new User({
+      email: "test@email.com",
+      password: "password2",
+    });
+    user2
+      .save()
+      .then(() => fail("No error raised when saving the file"))
+      .catch((error) => {});
+
+    const users = await User.find();
+    expect(users.length).toEqual(1);
   });
 });

--- a/api/spec/mongodb_helper.js
+++ b/api/spec/mongodb_helper.js
@@ -9,7 +9,7 @@ beforeAll(function (done) {
   var db = mongoose.connection;
   db.on("error", console.error.bind(console, "MongoDB connection error:"));
   db.on("open", function () {
-    done();
+    db.collections.users.drop(() => done());
   });
 });
 


### PR DESCRIPTION
- Adds [Bcrypt](https://www.npmjs.com/package/bcryptjs) Package to hash user passwords before adding them to the database.
- Adds tests on the backend to check that a user's email is unique

Example uses of Bcrypt package:
- Create a new hash:
```javascript
const password = "Hello World!";
const hash = await bcrypt
  .genSalt(10)
  .then((salt) => bcrypt.hash(password, salt))
  .catch((error) => console.error(error));
```
- Compare a hash and a given password:
```javascript
const password = "1234"
const hashedPassword = "askjdhfaskldjhfalkejhl";

// Boolean (true if the passwords match)
const match = await bcrypt
  .compare(password, hashedPassword)
  .catch((error) => console.error(error));
```

**Make sure you run**
```
npm install
```
**when pulling these changes to get the Bcrypt package.**
